### PR TITLE
Fix issue - Updating Profile Picture/Display Name doesn't work sometimes. #1207

### DIFF
--- a/changelog.d/1207.bugfix
+++ b/changelog.d/1207.bugfix
@@ -1,0 +1,1 @@
+MXUser.m: Add a property `latestUpdateTS` to update the user's avatar and displayname only when event.originServerTs > latestUpdateTS. Fixes issue - https://github.com/matrix-org/matrix-ios-sdk/issues/1207. Contributed by Anna.

--- a/changelog.d/1207.change
+++ b/changelog.d/1207.change
@@ -1,0 +1,1 @@
+MXUser.m: Add a property `latestUpdateTS` to update the user's avatar and displayname only when event.originServerTs > latestUpdateTS. Fixes issue - https://github.com/matrix-org/matrix-ios-sdk/issues/1207

--- a/changelog.d/1207.change
+++ b/changelog.d/1207.change
@@ -1,1 +1,0 @@
-MXUser.m: Add a property `latestUpdateTS` to update the user's avatar and displayname only when event.originServerTs > latestUpdateTS. Fixes issue - https://github.com/matrix-org/matrix-ios-sdk/issues/1207


### PR DESCRIPTION
Add a property `latestUpdateTS` to update the user's avatar and displayname only when `event.originServerTs` > `latestUpdateTS`. This fix is used to fix [the issue](https://github.com/matrix-org/matrix-ios-sdk/issues/1207)

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request contains a changelog file in ./changelog.d. See https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#changelog
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off)
